### PR TITLE
Set BitMono version as 0.0.0

### DIFF
--- a/props/SharedProjectProps.props
+++ b/props/SharedProjectProps.props
@@ -6,7 +6,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sunnamed434/BitMono</PackageProjectUrl>
     <PackageOwners>sunnamed434</PackageOwners>
-    <BitMonoVersion>0.19.1-alpha.35</BitMonoVersion>
+    <BitMonoVersion>0.0.0</BitMonoVersion>
     <PackageVersion>$(BitMonoVersion)</PackageVersion>
     <Version>$(BitMonoVersion)</Version>
     <InformationalVersion>$(BitMonoVersion)</InformationalVersion>


### PR DESCRIPTION
It makes 0 sense to have the version inside because anyway to release bitmono you need to create a new tag and specify the new version and CI will do all the stuff including the release