### PR TITLE
Improve the base type analyzer, making it more explicit

### DIFF
--- a/src/BitMono.Core/Analyzing/CriticalBaseTypesCriticalAnalyzer.cs
+++ b/src/BitMono.Core/Analyzing/CriticalBaseTypesCriticalAnalyzer.cs
@@ -1,6 +1,7 @@
-﻿namespace BitMono.Core.Analyzing;
+﻿using System.Text.RegularExpressions;
 
-[SuppressMessage("ReSharper", "InvertIf")]
+namespace BitMono.Core.Analyzing;
+
 public class CriticalBaseTypesCriticalAnalyzer : ICriticalAnalyzer<TypeDefinition>
 {
     private readonly CriticalsSettings _criticalsSettings;
@@ -12,19 +13,68 @@ public class CriticalBaseTypesCriticalAnalyzer : ICriticalAnalyzer<TypeDefinitio
 
     public bool NotCriticalToMakeChanges(TypeDefinition type)
     {
-        if (_criticalsSettings.UseCriticalBaseTypes == false)
+        if (!_criticalsSettings.UseCriticalBaseTypes)
         {
             return true;
         }
-        if (type.HasBaseType())
+        foreach (string ancestorFullName in YieldAncestors(type))
         {
-            var criticalBaseTypes = _criticalsSettings.CriticalBaseTypes!;
-            var typeBaseTypeName = type.BaseType?.Name?.Value.Split('`')[0] ?? string.Empty;
-            if (criticalBaseTypes.FirstOrDefault(c => c.StartsWith(typeBaseTypeName)) != null)
+            if (IsCriticalBaseType(ancestorFullName))
             {
                 return false;
             }
         }
         return true;
+    }
+
+    private bool IsCriticalBaseType(string ancestorFullName)
+    {
+        ancestorFullName = StripGenerics(ancestorFullName);
+        foreach (string criticalBaseType in _criticalsSettings.CriticalBaseTypes)
+        {
+            bool matches;
+            if (criticalBaseType.Contains('*'))
+            {
+                string regex = "^" + Regex.Escape(criticalBaseType).Replace(@"\*", ".*") + "$";
+                matches = Regex.IsMatch(ancestorFullName, regex);
+            }
+            else
+            {
+                matches = criticalBaseType == ancestorFullName;
+            }
+            if (matches)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string StripGenerics(string fullName)
+    {
+        int genericDelimeterIndex = fullName.IndexOf('`');
+        if (genericDelimeterIndex == -1)
+        {
+            return fullName;
+        }
+        return fullName[..genericDelimeterIndex];
+    }
+
+    /// <summary>
+    /// Yields the full class names of all ancestors across the inheritence chain of <paramref name="current"/>, including itself.
+    /// </summary>
+    private static IEnumerable<string> YieldAncestors(TypeDefinition? current)
+    {
+        while (current != null)
+        {
+            yield return current.FullName;
+            ITypeDefOrRef? baseType = current.BaseType;
+            current = baseType?.Resolve();
+            if (current == null && baseType != null)
+            {
+                //Type is in an unresolved dependency assembly, stop the search but yield the type name
+                yield return baseType.FullName;
+            }
+        }
     }
 }

--- a/src/BitMono.Host/criticals.json
+++ b/src/BitMono.Host/criticals.json
@@ -70,16 +70,15 @@
   "UseCriticalBaseTypes": true,
   "CriticalBaseTypes": [
     // RocketMod
-    "RocketPlugin",
+    "RocketPlugin*",
 
     // OpenMod
-    "OpenModUnturnedPlugin",
-    "OpenModUniversalPlugin",
-    "Command",
+    "OpenModUnturnedPlugin*",
+    "OpenModUniversalPlugin*",
+    "Command*",
 
     // rust-oxide-umod
-    "RustPlugin"
-
+    "RustPlugin*"
   ],
 
   // Exclude from obfuscation if the member starts with string


### PR DESCRIPTION
# Changes

1. `CriticalBaseTypesCriticalAnalyzer` currently only takes into account the immediate parent. This change considers the entire inheritance chain.
2. The analyzer now takes into account the namespace as well, by using `FullName` rather than `Name`, so you can now be exact in the types you specify
3. CriticalBaseTypes are now specified via glob patterns (e.g. "RocketPlugin*"), rather than the implicit "StartsWith", which allows matching **exact** class names by dropping the "*".
