### PR TITLE
Upgrade net462 dependencies to fix immediate crash

### DIFF
--- a/src/BitMono.Shared/BitMono.Shared.csproj
+++ b/src/BitMono.Shared/BitMono.Shared.csproj
@@ -77,15 +77,15 @@
 
   <!-- Packages specific to .NET Framework 4.6.2 -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1"/>
-    <PackageReference Include="Autofac.Configuration" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="Autofac.Configuration" Version="7.0.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="PolySharp" Version="1.15.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## What this does

BitMono currently immediately crashes when running on a .net 462 dll:

```
Something went wrong! System.MissingMethodException: Method not found:
'Void Autofac.Extensions.DependencyInjection.AutofacRegistration.Populate(Autofac.ContainerBuilder, System.Collections.Generic.IEnumerable1<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>)'.
at BitMono.Host.Modules.BitMonoModule.Load(ContainerBuilder containerBuilder)
```

This PR resolves the issue by upgrading the Autofac dependencies.

## What this doesn't do

Note that even after merging this, net462 support is still broken due to AsmResolver beta 4, see: https://github.com/Washi1337/AsmResolver/issues/678

Temporary fix:
1. `git revert c29ad7d` ([c29ad7d](https://github.com/sunnamed434/BitMono/commit/c29ad7d6577e03283e8ebf7550ca19c6ccd565a1))
2. `git revert 47984a9` ([47984a9](https://github.com/sunnamed434/BitMono/commit/47984a91120e21d3003c5fa2a422bd0fd3176811))