### PR TITLE
Fix the offsets of BitDecompiler and BitDotNet for x64 target

### DIFF
--- a/src/BitMono.Protections/BitDecompiler.cs
+++ b/src/BitMono.Protections/BitDecompiler.cs
@@ -23,7 +23,7 @@ public class BitDecompiler : PackerProtection
             stream.Position += 0x10;
             var x64PEOptionsHeader = reader.ReadUInt16() == 0x20B;
 
-            stream.Position += x64PEOptionsHeader ? 0x38 : 0x28 + 0xA6;
+            stream.Position += (x64PEOptionsHeader ? 0x38 : 0x28) + 0xA6;
             var dotNetVirtualAddress = reader.ReadUInt32();
 
             uint dotNetPointerRaw = 0;

--- a/src/BitMono.Protections/BitDotNet.cs
+++ b/src/BitMono.Protections/BitDotNet.cs
@@ -26,7 +26,7 @@ public class BitDotNet : PackerProtection
             stream.Position += 0x10;
             var x64PEOptionsHeader = reader.ReadUInt16() == 0x20B;
 
-            stream.Position += x64PEOptionsHeader ? 0x38 : 0x28 + 0xA6;
+            stream.Position += (x64PEOptionsHeader ? 0x38 : 0x28) + 0xA6;
             var dotNetVirtualAddress = reader.ReadUInt32();
 
             uint dotNetPointerRaw = 0;


### PR DESCRIPTION
The offsets will be calculated to 0x38 instead of 0xDE (0x38 + 0xA6) on original codes.

It leads "mono_image_open_from_data() failed: File does not contain a valid CIL image" on x64 platform(on my test)